### PR TITLE
Remove reference to self.executer

### DIFF
--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -246,11 +246,11 @@ class BackupWorker(object):
             path += ['*']
 
             with hide('output'):
-                path = self.executer.sudo('python -c "import os; print os.path.join(*%s)"' % path)
+                path = sudo('python -c "import os; print os.path.join(*%s)"' % path)
 
             logging.info('list files to backup matching %s path', path)
             with hide('output'):
-                files.extend([f.strip() for f in self.executer.sudo("ls %s" % path).split("\n")])
+                files.extend([f.strip() for f in sudo("ls %s" % path).split("\n")])
             logging.info("found %d files", len(files))
 
         return files


### PR DESCRIPTION
I deeply apologize, but a leftover of another feature I was working on crept into my previous pull request, which results in a bug. This pull request removes it.

(I was working on the ability to run the tool locally on the Cassandra nodes)
