### PR TITLE
Use glob instead of ls

### DIFF
--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -250,7 +250,8 @@ class BackupWorker(object):
 
             logging.info('list files to backup matching %s path', path)
             with hide('output'):
-                files.extend([f.strip() for f in sudo("ls %s" % path).split("\n")])
+                glob_results = sudo("python -c \"import glob; print '\\n'.join(glob.glob('%s'))\"" % path)
+                files.extend([f.strip() for f in glob_results.split("\n")])
             logging.info("found %d files", len(files))
 
         return files


### PR DESCRIPTION
When there are many files, `ls` fails on "argument list too big". I could rewrite it as `find`, but figured that's better to switch back to using glob (as it was before; just without pushy).
