### PR TITLE
Fix: restore worker keyspace/table matching regex.

### DIFF
--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -116,7 +116,7 @@ class RestoreWorker(object):
 
         bucket = self.s3connection.get_bucket(self.snapshot.s3_bucket)
 
-        matcher_string = "(%(hosts)s).*/(%(keyspace)s)/(%(table)s)" % dict(hosts='|'.join(hosts), keyspace=keyspace, table=table)
+        matcher_string = "(%(hosts)s).*/(%(keyspace)s)/(%(table)s)/" % dict(hosts='|'.join(hosts), keyspace=keyspace, table=table)
         self.keyspace_table_matcher = re.compile(matcher_string)
 
         keys = []


### PR DESCRIPTION
The regex wasn't matching the table name if no table name was passed (and `.*?` was used).
