### PR TITLE
Add multiple data directory support

### DIFF
--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -136,10 +136,11 @@ def put_from_manifest(s3_bucket, s3_connection_host, s3_ssenc, s3_base_path,
             os.remove(f)
 
 
-def get_data_path(config_path='/etc/cassandra/conf/cassandra.yaml'):
+def get_data_path(conf_path):
     '''
     Retrieve cassandra data_file_directories from cassandra.yaml
     '''
+    config_file_path = os.path.join(conf_path,'cassandra.yaml')
     cassandra_configs = {}
     with open(config_path, 'r') as f:
         cassandra_configs = yaml.load(f)
@@ -205,7 +206,7 @@ def main():
     manifest_parser.add_argument('--snapshot_name', required=True, type=str)
     manifest_parser.add_argument('--snapshot_keyspaces', default='', required=False, type=str)
     manifest_parser.add_argument('--snapshot_table', required=False, default='', type=str)
-    manifest_parser.add_argument('--data_paths', required=True, type=str)
+    manifest_parser.add_argument('--conf_path', required=True, type=str)
     manifest_parser.add_argument('--manifest_path', required=True, type=str)
 
     args = base_parser.parse_args()
@@ -233,6 +234,12 @@ def main():
             args.concurrency,
             args.incremental_backups
         )
+
+    if subcommand == 'get_data_path':
+        get_data_path(
+        args.conf_path
+        )
+
 
 if __name__ == '__main__':
     main()

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -142,7 +142,7 @@ def get_data_path(conf_path):
     '''
     config_file_path = os.path.join(conf_path,'cassandra.yaml')
     cassandra_configs = {}
-    with open(config_path, 'r') as f:
+    with open(config_file_path, 'r') as f:
         cassandra_configs = yaml.load(f)
     data_paths = cassandra_configs['data_file_directories']
     return data_paths

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -10,6 +10,7 @@ from multiprocessing.dummy import Pool
 import os
 import subprocess
 import time
+import yaml
 from timeout import timeout
 from utils import add_s3_arguments
 from utils import base_parser
@@ -135,7 +136,17 @@ def put_from_manifest(s3_bucket, s3_connection_host, s3_ssenc, s3_base_path,
             os.remove(f)
 
 
-def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, data_paths, manifest_path, incremental_backups=False):
+def get_data_path(config_path='/etc/cassandra/conf/cassandra.yaml'):
+    '''
+    Retrieve cassandra data_file_directories from cassandra.yaml
+    '''
+    cassandra_configs = {}
+    with open(config_path, 'r') as f:
+        cassandra_configs = yaml.load(f)
+    data_paths = cassandra_configs['data_file_directories']
+    return data_paths
+
+def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, manifest_path, incremental_backups=False):
     if snapshot_keyspaces:
         keyspace_globs = snapshot_keyspaces.split()
     else:
@@ -146,6 +157,7 @@ def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, da
     else:
         table_glob = '*'
 
+    data_paths = get_data_path()
     files = []
     for data_path in data_paths.split(','):
         print "processing {}".format(data_path)

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -216,7 +216,6 @@ def main():
             args.snapshot_name,
             args.snapshot_keyspaces,
             args.snapshot_table,
-            args.data_paths,
             args.manifest_path,
             args.incremental_backups
         )

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -162,7 +162,7 @@ def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, co
     files = []
     for data_path in data_paths:
         print "processing {}".format(data_path)
-        logger.info("processing {}".format(data_path))
+        logger.warning("Log!processing {}".format(data_path))
         for keyspace_glob in keyspace_globs:
             path = [
                 data_path,

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -161,8 +161,6 @@ def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, co
     data_paths = get_data_path(conf_path)
     files = []
     for data_path in data_paths:
-        print "processing {}".format(data_path)
-        logger.warning("Log!processing {}".format(data_path))
         for keyspace_glob in keyspace_globs:
             path = [
                 data_path,

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -3,6 +3,12 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from StringIO import StringIO
+from yaml import load
+try:
+    # LibYAML based parser and emitter
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 import glob
 import logging
 import multiprocessing
@@ -10,7 +16,6 @@ from multiprocessing.dummy import Pool
 import os
 import subprocess
 import time
-import yaml
 from timeout import timeout
 from utils import add_s3_arguments
 from utils import base_parser
@@ -143,7 +148,7 @@ def get_data_path(conf_path):
     config_file_path = os.path.join(conf_path,'cassandra.yaml')
     cassandra_configs = {}
     with open(config_file_path, 'r') as f:
-        cassandra_configs = yaml.load(f)
+        cassandra_configs = load(f, Loader=Loader)
     data_paths = cassandra_configs['data_file_directories']
     return data_paths
 

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -159,7 +159,7 @@ def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, ma
 
     data_paths = get_data_path()
     files = []
-    for data_path in data_paths.split(','):
+    for data_path in data_paths:
         print "processing {}".format(data_path)
         for keyspace_glob in keyspace_globs:
             path = [

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -147,7 +147,7 @@ def get_data_path(conf_path):
     data_paths = cassandra_configs['data_file_directories']
     return data_paths
 
-def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, manifest_path, incremental_backups=False):
+def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, conf_path, manifest_path, incremental_backups=False):
     if snapshot_keyspaces:
         keyspace_globs = snapshot_keyspaces.split()
     else:
@@ -217,6 +217,7 @@ def main():
             args.snapshot_name,
             args.snapshot_keyspaces,
             args.snapshot_table,
+            args.conf_path,
             args.manifest_path,
             args.incremental_backups
         )
@@ -234,12 +235,6 @@ def main():
             args.concurrency,
             args.incremental_backups
         )
-
-    if subcommand == 'get_data_path':
-        get_data_path(
-        args.conf_path
-        )
-
 
 if __name__ == '__main__':
     main()

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -158,7 +158,7 @@ def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, ma
     else:
         table_glob = '*'
 
-    data_paths = get_data_path()
+    data_paths = get_data_path(conf_path)
     files = []
     for data_path in data_paths:
         print "processing {}".format(data_path)

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -162,6 +162,7 @@ def create_upload_manifest(snapshot_name, snapshot_keyspaces, snapshot_table, co
     files = []
     for data_path in data_paths:
         print "processing {}".format(data_path)
+        logger.info("processing {}".format(data_path))
         for keyspace_glob in keyspace_globs:
             path = [
                 data_path,

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -136,9 +136,9 @@ def main():
                                default='',
                                help='The table (column family) to backup')
 
-    backup_parser.add_argument('--cassandra-data-path',
-                               default='/var/lib/cassandra/data/',
-                               help='cassandra data path.')
+    backup_parser.add_argument('--cassandra-conf-path',
+                               default='/etc/cassandra/conf/',
+                               help='cassandra config file path.')
 
     backup_parser.add_argument('--nodetool-path',
                                default=None,

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -45,7 +45,7 @@ def run_backup(args):
         s3_bucket_region=args.s3_bucket_region,
         s3_ssenc=args.s3_ssenc,
         s3_connection_host=get_s3_connection_host(args.s3_bucket_region),
-        cassandra_data_path=args.cassandra_data_path,
+        cassandra_conf_path=args.cassandra_conf_path,
         nodetool_path=args.nodetool_path,
         cassandra_bin_dir=args.cassandra_bin_dir,
         backup_schema=args.backup_schema,

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -220,7 +220,8 @@ class BackupWorker(object):
     """
 
     def __init__(self, aws_secret_access_key,
-                 aws_access_key_id, s3_bucket_region, s3_ssenc, s3_connection_host, cassandra_data_path,
+                 aws_access_key_id, s3_bucket_region, s3_ssenc,
+                 s3_connection_host, cassandra_conf_path,
                  nodetool_path, cassandra_bin_dir, backup_schema,
                  connection_pool_size=12):
         self.aws_secret_access_key = aws_secret_access_key
@@ -228,7 +229,7 @@ class BackupWorker(object):
         self.s3_bucket_region = s3_bucket_region
         self.s3_ssenc = s3_ssenc
         self.s3_connection_host = s3_connection_host
-        self.cassandra_data_path = cassandra_data_path
+        self.cassandra_conf_path = cassandra_conf_path
         self.nodetool_path = nodetool_path or "%s/nodetool" % cassandra_bin_dir
         self.cassandra_cli_path = "%s/cassandra-cli" % cassandra_bin_dir
         self.backup_schema = backup_schema
@@ -248,16 +249,15 @@ class BackupWorker(object):
             --snapshot_name=%(snapshot_name)s \
             --snapshot_keyspaces=%(snapshot_keyspaces)s \
             --snapshot_table=%(snapshot_table)s \
-            --data_paths=%(data_paths)s"
+            --conf_path=%(conf_path)s"
         cmd = manifest_command % dict(
             manifest_path=manifest_path,
             snapshot_name=snapshot.name,
             snapshot_keyspaces=snapshot.keyspaces,
             snapshot_table=snapshot.table,
-            data_paths=self.cassandra_data_path,
+            data_path=self.cassandra_conf_path,
             incremental_backups=incremental_backups and '--incremental_backups' or ''
         )
-        print "manifest_command is {0}".format(cmd)
         sudo(cmd)
 
         upload_command = "cassandra-snapshotter-agent %(incremental_backups)s \
@@ -279,7 +279,6 @@ class BackupWorker(object):
             manifest=manifest_path,
             incremental_backups=incremental_backups and '--incremental_backups' or ''
         )
-        print "upload_command============ is {0}".format(cmd)
         sudo(cmd)
 
     def snapshot(self, snapshot):
@@ -382,9 +381,8 @@ class BackupWorker(object):
             table_param=table_param
         )
 
-        #with hide('running', 'stdout', 'stderr'):
-        #    sudo(cmd)
-        sudo(cmd)
+        with hide('running', 'stdout', 'stderr'):
+            sudo(cmd)
 
     def upload_cluster_backups(self, snapshot, incremental_backups):
         logging.info('Uploading backups')

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -242,18 +242,33 @@ class BackupWorker(object):
             '/') + [self.get_current_node_hostname()])
 
         manifest_path = '/tmp/backupmanifest'
-        manifest_command = "cassandra-snapshotter-agent %(incremental_backups)s create-upload-manifest --manifest_path=%(manifest_path)s --snapshot_name=%(snapshot_name)s --snapshot_keyspaces=%(snapshot_keyspaces)s --snapshot_table=%(snapshot_table)s --data_path=%(data_path)s"
+        manifest_command = "cassandra-snapshotter-agent \
+            %(incremental_backups)s create-upload-manifest \
+            --manifest_path=%(manifest_path)s \
+            --snapshot_name=%(snapshot_name)s \
+            --snapshot_keyspaces=%(snapshot_keyspaces)s \
+            --snapshot_table=%(snapshot_table)s \
+            --data_paths=%(data_paths)s"
         cmd = manifest_command % dict(
             manifest_path=manifest_path,
             snapshot_name=snapshot.name,
             snapshot_keyspaces=snapshot.keyspaces,
             snapshot_table=snapshot.table,
-            data_path=self.cassandra_data_path,
+            data_paths=self.cassandra_data_path,
             incremental_backups=incremental_backups and '--incremental_backups' or ''
         )
+        print "manifest_command is {0}".format(cmd)
         sudo(cmd)
 
-        upload_command = "cassandra-snapshotter-agent %(incremental_backups)s put --aws-access-key-id=%(key)s --aws-secret-access-key=%(secret)s --s3-bucket-name=%(bucket)s --s3-bucket-region=%(s3_bucket_region)s %(s3_ssenc)s --s3-base-path=%(prefix)s --manifest=%(manifest)s --concurrency=4"
+        upload_command = "cassandra-snapshotter-agent %(incremental_backups)s \
+            put \
+            --aws-access-key-id=%(key)s \
+            --aws-secret-access-key=%(secret)s \
+            --s3-bucket-name=%(bucket)s \
+            --s3-bucket-region=%(s3_bucket_region)s %(s3_ssenc)s \
+            --s3-base-path=%(prefix)s \
+            --manifest=%(manifest)s \
+            --concurrency=4"
         cmd = upload_command % dict(
             bucket=snapshot.s3_bucket,
             s3_bucket_region=self.s3_bucket_region,
@@ -264,6 +279,7 @@ class BackupWorker(object):
             manifest=manifest_path,
             incremental_backups=incremental_backups and '--incremental_backups' or ''
         )
+        print "upload_command============ is {0}".format(cmd)
         sudo(cmd)
 
     def snapshot(self, snapshot):
@@ -366,8 +382,9 @@ class BackupWorker(object):
             table_param=table_param
         )
 
-        with hide('running', 'stdout', 'stderr'):
-            sudo(cmd)
+        #with hide('running', 'stdout', 'stderr'):
+        #    sudo(cmd)
+        sudo(cmd)
 
     def upload_cluster_backups(self, snapshot, incremental_backups):
         logging.info('Uploading backups')

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -255,7 +255,7 @@ class BackupWorker(object):
             snapshot_name=snapshot.name,
             snapshot_keyspaces=snapshot.keyspaces,
             snapshot_table=snapshot.table,
-            data_path=self.cassandra_conf_path,
+            conf_path=self.cassandra_conf_path,
             incremental_backups=incremental_backups and '--incremental_backups' or ''
         )
         sudo(cmd)


### PR DESCRIPTION
Removed the "--cassandra-data-path" command line parameter, added "--cassandra-conf-path". Data directory(s) now is (are) retrieved from the "cassandra.yaml" file.  