### PR TITLE
Add eu-central-1

### DIFF
--- a/cassandra_snapshotter/utils.py
+++ b/cassandra_snapshotter/utils.py
@@ -5,6 +5,7 @@ S3_CONNECTION_HOSTS = {
     'us-east-1': 's3.amazonaws.com',
     'us-west-2': 's3-us-west-2.amazonaws.com',
     'us-west-1': 's3-us-west-1.amazonaws.com',
+    'eu-central-1': 's3-eu-central-1.amazonaws.com',
     'eu-west-1': 's3-eu-west-1.amazonaws.com',
     'ap-southeast-1': 's3-ap-southeast-1.amazonaws.com',
     'ap-southeast-2': 's3-ap-southeast-2.amazonaws.com',


### PR DESCRIPTION
This region enforces Signature v4, but with validate=False when getting
a bucket this should not matter.
See https://github.com/boto/boto/issues/2741 for reference