### PR TITLE
Add argument to pass an SSH key file.

### DIFF
--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -187,7 +187,8 @@ def main():
         default='',
         help="User password to connect with hosts")
 
-    backup_parser.add_argument('--sshkey',
+    backup_parser.add_argument(
+        '--sshkey',
         help="The file containing the private ssh key to use to connect with hosts")
 
     backup_parser.add_argument(

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -21,6 +21,9 @@ def run_backup(args):
     if args.password:
         env.password = args.password
 
+    if args.sshkey:
+        env.key_filename = args.sshkey
+
     if args.sshport:
         env.port = args.sshport
 
@@ -183,6 +186,9 @@ def main():
         '--password',
         default='',
         help="User password to connect with hosts")
+
+    backup_parser.add_argument('--sshkey',
+        help="The file containing the private ssh key to use to connect with hosts")
 
     backup_parser.add_argument(
         '--new-snapshot',


### PR DESCRIPTION
A simple change to add an argument to for an SSH private key file. There's another outstanding pull request to do the same thing but it looks dead, and this uses the same flag name as the DemandLogic fork so theirs will be easier to merge if they decide to do so.
Cheers,
Avi