### PR TITLE
Get --keyspaces working with multiple keyspaces

### DIFF
--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -139,14 +139,15 @@ def put_from_manifest(
     files = manifest_fp.read().splitlines()
     pool = Pool(concurrency)
     for ret in pool.imap(upload_file,
-                         ((bucket, f, destination_path(s3_base_path, f), s3_ssenc, buffer_size) for f in files)):
+                         ((bucket, f, destination_path(s3_base_path, f), s3_ssenc, buffer_size) for f in files if f)):
         if not ret:
             exit_code = 1
             break
     pool.terminate()
     if incremental_backups:
         for f in files:
-            os.remove(f)
+            if f:
+                os.remove(f)
     exit(exit_code)
 
 
@@ -164,7 +165,7 @@ def create_upload_manifest(
         snapshot_name, snapshot_keyspaces, snapshot_table,
         conf_path, manifest_path, incremental_backups=False):
     if snapshot_keyspaces:
-        keyspace_globs = snapshot_keyspaces.split()
+        keyspace_globs = snapshot_keyspaces.split(',')
     else:
         keyspace_globs = ['*']
 

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -25,6 +25,7 @@ def run_backup(args):
         env.port = args.sshport
 
     env.hosts = args.hosts.split(',')
+    env.keyspaces = args.keyspaces.split(',') if args.keyspaces else None
 
     if args.new_snapshot:
         create_snapshot = True
@@ -36,7 +37,7 @@ def run_backup(args):
             args.s3_bucket_name
         ).get_snapshot_for(
             hosts=env.hosts,
-            keyspaces=args.keyspaces,
+            keyspaces=env.keyspaces,
             table=args.table
         )
         create_snapshot = existing_snapshot is None
@@ -62,7 +63,7 @@ def run_backup(args):
             base_path=args.s3_base_path,
             s3_bucket=args.s3_bucket_name,
             hosts=env.hosts,
-            keyspaces=args.keyspaces,
+            keyspaces=env.keyspaces,
             table=args.table
         )
         worker.snapshot(snapshot)
@@ -139,12 +140,12 @@ def main():
     backup_parser.add_argument(
         '--hosts',
         required=True,
-        help="The comma separated list of hosts to snapshot")
+        help="Comma separated list of hosts to snapshot")
 
     backup_parser.add_argument(
         '--keyspaces',
         default='',
-        help="The keyspaces to backup (omit to backup all)")
+        help="Comma separated list of keyspaces to backup (omit to backup all)")
 
     backup_parser.add_argument(
         '--table',

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -411,11 +411,11 @@ class BackupWorker(object):
         """Runs snapshot command on a cassandra node"""
 
         def run_cmd(cmd):
-           with hide('running', 'stdout', 'stderr'):
-               if self.use_sudo:
-                   sudo(cmd)
-               else:
-                   run(cmd)
+            with hide('running', 'stdout', 'stderr'):
+                if self.use_sudo:
+                    sudo(cmd)
+                else:
+                    run(cmd)
 
         if incremental_backups:
             backup_command = "%(nodetool)s flush %(keyspace)s %(tables)s"


### PR DESCRIPTION
Add support for passing multiple (comma separated) keyspaces with --keyspaces.
In the agent that means splitting on commas not on spaces.  While spaces could
be used to separate keyspaces this requires quoting the argument passed to the
agent.  Using commas is simpler.  While there, don't try to remove files with
name the empty string '' (you get this if the manifest is completely empty in
incremental mode).
The snapshotting logic was conflicted as to whether it was expecting a comma
separated or whitespace separated list.  Now it gets a real list (this is set
up in main.my) or None if no keyspaces passed.  The list is then joined with
spaces when calling nodetool and with commas when calling the agent.  Most of
the work was in node_start_backup, which had multiple problems:
  (1) In incremental mode, if a table was specified, an invalid flush command
      would be generated (needs a keyspace);
  (2) In incremental mode, if there are multiple keyspaces then flush has to
      be called multiple times (because nodetool flush doesn't support flushing
      multiple keyspaces in one call);
  (3) In snapshot mode, if a table is specified then at most one keyspace can
      be provided.
While there, fix the schema output when using explicitly specified multiple
keyspaces: before you got a file per keyspace, but every file had the same
contents: the schema for all keyspaces.  Now the schema file for a keyspace
only has the schema for that keyspace.