### PR TITLE
Added exclude tables option

### DIFF
--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -162,7 +162,7 @@ def get_data_path(conf_path):
 
 def create_upload_manifest(
         snapshot_name, snapshot_keyspaces, snapshot_table,
-        conf_path, manifest_path, incremental_backups=False):
+        conf_path, manifest_path, exclude_tables, incremental_backups=False):
     if snapshot_keyspaces:
         keyspace_globs = snapshot_keyspaces.split()
     else:
@@ -175,6 +175,7 @@ def create_upload_manifest(
 
     data_paths = get_data_path(conf_path)
     files = []
+    exclude_tables_list = exclude_tables.split(',')
     for data_path in data_paths:
         for keyspace_glob in keyspace_globs:
             path = [
@@ -189,8 +190,15 @@ def create_upload_manifest(
             path += ['*']
 
             path = os.path.join(*path)
-            glob_results = '\n'.join(glob.glob(os.path.join(path)))
-            files.extend([f.strip() for f in glob_results.split("\n")])
+            if len(exclude_tables_list) > 0:
+                for f in glob.glob(os.path.join(path)):
+                    # Get the table name
+                    # The current format of a file path looks like:
+                    # /var/lib/cassandra/data03/system/compaction_history/snapshots/20151102182658/system-compaction_history-jb-6684-Summary.db
+                    if f.split('/')[-4] not in exclude_tables_list:
+                        files.append(f.strip())
+            else:
+                files.append(f.strip() for f in glob.glob(os.path.join(path)))
 
     with open(manifest_path, 'w') as manifest:
         manifest.write('\n'.join("%s" % f for f in files))
@@ -236,6 +244,8 @@ def main():
         '--snapshot_keyspaces', default='', required=False, type=str)
     manifest_parser.add_argument(
         '--snapshot_table', required=False, default='', type=str)
+    manifest_parser.add_argument(
+        '--exclude_tables', required=False, type=str)
 
     args = base_parser.parse_args()
     subcommand = args.subcommand
@@ -247,6 +257,7 @@ def main():
             args.snapshot_table,
             args.conf_path,
             args.manifest_path,
+            args.exclude_tables,
             args.incremental_backups
         )
 

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -53,7 +53,8 @@ def run_backup(args):
         backup_schema=args.backup_schema,
         buffer_size=args.buffer_size,
         use_sudo=args.use_sudo,
-        connection_pool_size=args.connection_pool_size
+        connection_pool_size=args.connection_pool_size,
+        exclude_tables=args.exclude_tables
     )
 
     if create_snapshot:
@@ -135,6 +136,11 @@ def main():
         '--buffer-size',
         default=64,
         help="The buffer size (MB) for compress and upload")
+
+    backup_parser.add_argument(
+        '--exclude-tables',
+        default='',
+        help="Column families you want to skip")
 
     backup_parser.add_argument(
         '--hosts',

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -248,7 +248,7 @@ class BackupWorker(object):
                  aws_access_key_id, s3_bucket_region, s3_ssenc,
                  s3_connection_host, cassandra_conf_path, use_sudo,
                  nodetool_path, cassandra_bin_dir, backup_schema,
-                 buffer_size, connection_pool_size=12):
+                 buffer_size, exclude_tables, connection_pool_size=12):
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_access_key_id = aws_access_key_id
         self.s3_bucket_region = s3_bucket_region
@@ -264,6 +264,7 @@ class BackupWorker(object):
             self.use_sudo = bool(strtobool(use_sudo))
         else:
             self.use_sudo = use_sudo
+        self.exclude_tables = exclude_tables
 
     def get_current_node_hostname(self):
         return env.host_string
@@ -279,13 +280,15 @@ class BackupWorker(object):
                            "--snapshot_name=%(snapshot_name)s " \
                            "--snapshot_keyspaces=%(snapshot_keyspaces)s " \
                            "--snapshot_table=%(snapshot_table)s " \
-                           "--conf_path=%(conf_path)s"
+                           "--conf_path=%(conf_path)s " \
+                           "--exclude_tables=%(exclude_tables)s"
         cmd = manifest_command % dict(
             manifest_path=manifest_path,
             snapshot_name=snapshot.name,
             snapshot_keyspaces=snapshot.keyspaces,
             snapshot_table=snapshot.table,
             conf_path=self.cassandra_conf_path,
+            exclude_tables=self.exclude_tables,
             incremental_backups=incremental_backups and '--incremental_backups' or ''
         )
         if self.use_sudo:


### PR DESCRIPTION
Added exclude tables option, in the case of you don't want to backup all tables.

Example:
cassandra-snapshotter --aws-access-key-id=key_id --aws-secret-access-key=key --s3-ssenc --s3-bucket-name='bucket' --s3-base-path='base' backup --hosts=host1--exclude-tables='table,table2' --use-sudo=False --user=user --backup-schema --new-snapshot