### PR TITLE
Use pipe instead of -e to run cqlsh commands

### DIFF
--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -365,10 +365,10 @@ class BackupWorker(object):
     def get_keyspace_schema(self, keyspace=None):
         with settings(host_string=env.hosts[0]):
             with hide('output'):
-                cmd = "{!s} -e 'DESCRIBE SCHEMA;'".format(self.cqlsh_path)
+                cmd = "echo 'DESCRIBE SCHEMA;' | {!s}".format(self.cqlsh_path)
                 if keyspace:
-                    cmd = "{!s} -e 'DESCRIBE KEYSPACE {!s};' -k {!s}".format(
-                        self.cqlsh_path, keyspace, keyspace)
+                    cmd = "echo 'DESCRIBE KEYSPACE {!s};' | {!s} -k {!s}".format(
+                        keyspace, self.cqlsh_path, keyspace)
                 if self.use_sudo:
                     output = sudo(cmd)
                 else:


### PR DESCRIPTION
Using -e caused error with cqlsh 4.1.1 installed via pip:
$ /usr/local/bin/cqlsh --version
cqlsh 4.1.1

Log output:
Requested: /usr/local/bin/cqlsh -e 'DESCRIBE SCHEMA;'
Executed: /bin/bash -l -c "/usr/local/bin/cqlsh -e 'DESCRIBE SCHEMA;'"

Usage: cqlsh [options] [host [port]]
cqlsh: error: no such option: -e


Using the pipe method fixed this for me.