### PR TITLE
Improve restore

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -8,3 +8,4 @@ Chris Love
 Tony Li Xu
 Mathew Kamkar
 Alessandro Pieri
+Romain Hardouin

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Usage
 
 You can see the list of parameters available via `cassandra-snapshotter --help`
 
+If you want to make `cassandra-snapshotter` more chatty just add `--verbose`.
+
 ####Create a new backup for *mycluster*:####
 
 
@@ -42,6 +44,7 @@ cassandra-snapshotter --s3-bucket-name=Z \
                       --aws-access-key-id=X \ # optional
                       --aws-secret-access-key=Y \ # optional
                       --s3-ssenc \ # optional
+                      --verbose \ # optional
                       backup \
                       --hosts=h1,h2,h3,h4 \
                       --user=cassandra # optional
@@ -116,12 +119,123 @@ Its not in the scope of this project to clean up your S3 buckets.
 S3 Lifecycle rules allows you do drop or archive to Glacier object stored based on their age.
 
 ###Restore your data###
-cassandra_snaphotter tries to store data and metadata in a way to make restores less painful; There is not (yet) a feature complete restore command; every patch / pull request about this is more than welcome (hint hint).
 
-In case you need, cassandra_snapshotter stores the ring token description every time a backup is done ( you can find it the ring file in the snapshot base path )
+There are two types of restore:
+ * using `sstableloader` (manual or automatic)
+ * local restore: download data on the local server
 
-The way data is stored on S3 should makes it really easy to use the Node Restart Method (https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_backup_snapshot_restore_t.html#task_ds_vf4_z1r_gk)
+####sstableloader (automatic)####
 
+Mandatory parameters:
+
+ * `--target-hosts TARGET_HOSTS`: the comma separated list of hosts to restore into. These hosts will received data from sstableloader.
+ * `--keyspace KEYSPACE`: the keyspace to restore.
+
+Optional parameters:
+
+ * `--hosts`: comma separated list of hosts to restore from; leave empty for all
+ * `--table TABLE`: the table (column family) to restore; leave blank for all
+ * `--restore-dir`: where to download files from S3 before to stream them. Default: `/tmp/restore_cassandra/`
+ * `--snapshot-name SNAPSHOT_NAME`: the name of the snapshot to restore
+
+Example to restore `Keyspace1` on `10.0.100.77` with data fetched from a two nodes backup:
+
+``` bash
+cassandra-snapshotter --s3-bucket-name=Z \
+                      --s3-bucket-region=eu-west-1 \
+                      --s3-base-path=mycluster \
+                      --aws-access-key-id=X \ # optional
+                      --aws-secret-access-key=Y \ # optional
+                      restore \
+                      --hosts=10.0.2.68,10.0.2.67 \ # optional
+                      --target-hosts=10.0.100.77 \ # where to restore data
+                      --keyspace Keyspace1 \
+                      --snapshot-name 20160614202644 \ # optional
+                      --restore-dir /tmp/cassandra_restore/ # optional
+```
+
+Make sure there is enough free disk space on the `--restore-dir` filesystem.
+
+####sstableloader (manual)####
+
+If you want to restore files without loading them via `sstableloader` automatically, you can use the `--no-sstableloader` option.
+Data will just be downloaded. Use it if you want to do some checks and then run sstableloader manually.
+
+The files are saved following this format:
+
+``` bash
+<--restore-dir>/<--keyspace>/<--table>/<HOST>_<filename>
+```
+
+Example:
+
+``` bash
+/tmp/cassandra_restore/Keyspace1/Standard1/10.0.53.68_Keyspace1-Standard1-jb-1-Data.db
+```
+
+Again, make sure there is enough free disk space on the `--restore-dir` filesystem.
+
+####Local restore####
+
+If you have lots of data you probably don't want to download data on a server and then stream these data with `sstableloader` on another one server.
+The `--local` option allows you to restore data directly on the local server where the command is run. Note this procedure allows to restore only one host,
+so if you want to restore several nodes you have a to run this command on each server.
+
+On production, do not restore directly on the C* data directory (e.g. --restore-dir /var/lib/cassandra/data/ ) it's safer to restore on a different location.
+Then make some checks (Number of files seems good? The total size seems correct? Files are uncompressed? What about file permissions?) and if all is OK just `mv` the data.
+To make the `mv` command fast, just download data on the same filesystem.
+Also prior to run the command ensure that the filesystem can host the data (enough free disk space).
+
+Example:
+
+Let's say we have a filesystem mounted on `/cassandra`.
+We want to download files on `/cassandra/restore/` (no need to create the `restore` directory, `cassandra_snapshotter` will create it).
+
+The following command will restore from `10.0.2.68` on the local server into `/cassandra/restore/`:
+
+``` bash
+cassandra-snapshotter --s3-bucket-name=Z \
+                      --s3-bucket-region=eu-west-1 \
+                      --s3-base-path=mycluster \
+                      --aws-access-key-id=X \ # optional
+                      --aws-secret-access-key=Y \ # optional
+                      --verbose \
+                      restore \
+                      --hosts=10.0.2.68 \ # select the source host. Only one node is allowed in local restore.
+                      --snapshot-name 20160614202644 \ # optional
+                      --restore-dir /cassandra/restore/ \ #
+                      --keyspace Keyspace1 \
+                      --local
+```
+
+The files are saved following this format:
+
+``` bash
+<--restore-dir>/<--keyspace>/<--table>/<filename>
+```
+
+Note the filenames are *not* prefixed by `<HOST>_` because we restore from only one node in this mode, so it would be useless.
+
+Example:
+
+``` bash
+/tmp/cassandra_restore/Keyspace1/Standard1/Keyspace1-Standard1-jb-1-Data.db
+```
+
+Here are the DataStax procedures to follow when using a local restore:
+ * Cassandra v2.0: https://docs.datastax.com/en/cassandra/2.0/cassandra/operations/ops_backup_snapshot_restore_t.html
+ * Cassandra v2.1: https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_backup_snapshot_restore_t.html
+ * Cassandra v2.2: http://docs.datastax.com/en/cassandra/2.2/cassandra/operations/opsBackupSnapshotRestore.html
+ * Cassandra v3.x: http://docs.datastax.com/en/cassandra/3.x/cassandra/operations/opsBackupSnapshotRestore.html
+
+###Ring information###
+
+In case you need, cassandra_snapshotter stores the ring token description every time a backup is done.
+
+You can find it in the `ring` file in the snapshot base path, for instance:
+
+```
+/test-cassandra-snapshots/cassandrasnapshots/20160614202644/ring
+```
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/tbarbugli/cassandra_snapshotter/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/cassandra_snapshotter/__init__.py
+++ b/cassandra_snapshotter/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 __maintainer__ = 'Tommaso Barbugli'
 __email__ = 'tbarbugli@gmail.com'

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -51,7 +51,7 @@ def get_bucket(
 
 def destination_path(s3_base_path, file_path, compressed=True):
     suffix = compressed and '.lzo' or ''
-    return '/'.join([s3_base_path, file_path + suffix])
+    return os.path.join(s3_base_path, file_path + suffix)
 
 
 def s3_progress_update_callback(*args):

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -51,7 +51,8 @@ def get_bucket(
 
 def destination_path(s3_base_path, file_path, compressed=True):
     suffix = compressed and '.lzo' or ''
-    return os.path.join(s3_base_path, file_path + suffix)
+    dest_path = "{}{}{}".format(s3_base_path, file_path, suffix)
+    return dest_path
 
 
 def s3_progress_update_callback(*args):

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -301,8 +301,10 @@ def main():
     restore_parser.add_argument(
         '--restore-dir',
         default='/tmp/restore_cassandra/',
-        help="Directory where data will be downloaded. If --target-hosts is "
-             "passed, sstableloader will stream data from this directory.")
+        help="Directory where data will be downloaded. "
+             "Existing data in this directory will be *ERASED*. "
+             "If --target-hosts is passed, sstableloader will stream data "
+             "from this directory.")
 
     restore_type = restore_parser.add_mutually_exclusive_group(required=True)
 

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -290,8 +290,8 @@ def main():
     restore_parser.add_argument(
         '--hosts',
         default='',
-        help="Comma separated list of \
-            hosts to restore from; leave empty for all")
+        help="Comma separated list of hosts to restore from; "
+             "leave empty for all. Only one host allowed when using --local.")
 
     restore_parser.add_argument(
         '--cassandra-bin-dir',

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, print_function)
 # From system
 from collections import defaultdict
 from fabric.api import env
+import os.path
 import logging
 
 # From package
@@ -94,8 +95,8 @@ def list_backups(args):
     path_snapshots = defaultdict(list)
 
     for snapshot in snapshots:
-        base_path = '/'.join(snapshot.base_path.split('/')[:-1])
-        path_snapshots[base_path].append(snapshot)
+        dir_path = os.path.dirname(snapshot.base_path)
+        path_snapshots[dir_path].append(snapshot)
 
     for path, snapshots in path_snapshots.iteritems():
         print("-----------[{!s}]-----------".format(path))

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -124,7 +124,8 @@ def restore_backup(args):
                            aws_secret_access_key=args.aws_secret_access_key,
                            snapshot=snapshot,
                            cassandra_bin_dir=args.cassandra_bin_dir,
-                           cassandra_data_dir=args.cassandra_data_dir)
+                           cassandra_data_dir=args.cassandra_data_dir,
+                           no_sstableloader=args.no_sstableloader)
 
     if args.hosts:
         hosts = args.hosts.split(',')
@@ -290,6 +291,11 @@ def main():
         '--cassandra-data-dir',
         default='/usr/local/cassandra/data',
         help="cassandra data directory")
+
+    restore_parser.add_argument(
+        '--no-sstableloader',
+        action='store_true',
+        help="Do not run sstableloader when restoring. If set, files will just be downloaded.")
 
     args = base_parser.parse_args()
     subcommand = args.subcommand

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -120,7 +120,8 @@ class RestoreWorker(object):
         bucket = self.s3connection.get_bucket(
             self.snapshot.s3_bucket, validate=False)
 
-        matcher_string = "(%(hosts)s).*/(%(keyspace)s)/(%(table)s-[A-Za-z0-9]*)/" % dict(
+        # handle v2.0 and v2.1 table directory format
+        matcher_string = "(%(hosts)s).*/(%(keyspace)s)/(%(table)s-?[A-Za-z0-9]*)/" % dict(
             hosts='|'.join(hosts), keyspace=keyspace, table=table)
         self.keyspace_table_matcher = re.compile(matcher_string)
 

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -135,7 +135,7 @@ class RestoreWorker(object):
             tables.add(r.group(3))
             keys.append(k)
 
-        keyspace_path = "/".join([self.cassandra_data_dir, "data", keyspace])
+        keyspace_path = os.path.join(self.cassandra_data_dir, keyspace)
         self._delete_old_dir_and_create_new(keyspace_path, tables)
         total_size = reduce(lambda s, k: s + k.size, keys, 0)
 

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from fabric.api import (env, execute, hide, run, sudo)
 from fabric.context_managers import settings
 from multiprocessing.dummy import Pool
-from cassandra_snapshotter.utils import decompression_pipe
+from cassandra_snapshotter.utils import check_lzop, decompression_pipe
 
 
 class Snapshot(object):
@@ -111,6 +111,7 @@ class RestoreWorker(object):
     def restore(self, keyspace, table, hosts, target_hosts):
         logging.info("Restoring keyspace=%(keyspace)s,\
             table=%(table)s" % dict(keyspace=keyspace, table=table))
+        check_lzop()
         logging.info("From hosts: %(hosts)s to: %(target_hosts)s" % dict(
             hosts=', '.join(hosts), target_hosts=', '.join(target_hosts)))
         if not table:


### PR DESCRIPTION
The most important commit is "Fix restore: use absolute path" (665a97b). I was unable to restore with relative path because the script tried to download files in the current working directory instead of `--cassandra-data-dir` i.e. where the directory tree is created.

Also add:
- sstableloader is now optional with `--no-sstableloader`
- Handle v2.0 and v2.1 table directory format: v.2.0 doesn't have UUID
- Add error handling and logging
- Check if lzop is available when restoring
- Some refactoring
