### PR TITLE
Quiet mode

### DIFF
--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -61,7 +61,8 @@ def run_backup(args):
         connection_pool_size=args.connection_pool_size,
         exclude_tables=args.exclude_tables,
         reduced_redundancy=args.reduced_redundancy,
-        rate_limit=args.rate_limit
+        rate_limit=args.rate_limit,
+        quiet=args.quiet
     )
 
     if create_snapshot:
@@ -229,6 +230,12 @@ def main():
         '--rate-limit',
         default=0,
         help="Limit the upload speed to S3 (by using 'pv'). Value expressed in kilobytes (*1024)")
+
+    backup_parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help="Set pv in quiet mode when using --rate-limit. "
+             "Useful when called by a script.")
 
     # restore snapshot arguments
     restore_parser = subparsers.add_parser(

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -252,8 +252,8 @@ class BackupWorker(object):
                  aws_access_key_id, s3_bucket_region, s3_ssenc,
                  s3_connection_host, cassandra_conf_path, use_sudo,
                  nodetool_path, cassandra_bin_dir, backup_schema,
-                 buffer_size, exclude_tables, rate_limit, connection_pool_size=12,
-                 reduced_redundancy=False):
+                 buffer_size, exclude_tables, rate_limit, quiet,
+                 connection_pool_size=12, reduced_redundancy=False):
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_access_key_id = aws_access_key_id
         self.s3_bucket_region = s3_bucket_region
@@ -267,6 +267,7 @@ class BackupWorker(object):
         self.buffer_size = buffer_size
         self.reduced_redundancy = reduced_redundancy
         self.rate_limit = rate_limit
+        self.quiet = quiet
         if isinstance(use_sudo, basestring):
             self.use_sudo = bool(strtobool(use_sudo))
         else:
@@ -316,6 +317,9 @@ class BackupWorker(object):
 
         if self.rate_limit > 0:
             upload_command += " --rate-limit=%(rate_limit)s"
+
+        if self.quiet:
+            upload_command += " --quiet"
 
         if self.aws_access_key_id and self.aws_secret_access_key:
             upload_command += " --aws-access-key-id=%(key)s " \

--- a/cassandra_snapshotter/utils.py
+++ b/cassandra_snapshotter/utils.py
@@ -76,18 +76,20 @@ def map_wrap(f):
     return wrapper
 
 
-def check_lzop():
+def _check_bin(bin_name):
     try:
-        subprocess.call([LZOP_BIN, '--version'])
-    except OSError:
-        sys.exit("{!s} not found on path".format(LZOP_BIN))
+        subprocess.check_call("{} --version > /dev/null 2>&1".format(bin_name),
+                              shell=True)
+    except subprocess.CalledProcessError:
+        sys.exit("{} not found on path".format(bin_name))
+
+
+def check_lzop():
+    _check_bin(LZOP_BIN)
 
 
 def check_pv():
-    try:
-        subprocess.call([PV_BIN, '--version'])
-    except OSError:
-        sys.exit("{!s} not found on path".format(PV_BIN))
+    _check_bin(PV_BIN)
 
 
 def compressed_pipe(path, size, rate_limit):

--- a/cassandra_snapshotter/utils.py
+++ b/cassandra_snapshotter/utils.py
@@ -92,7 +92,7 @@ def check_pv():
     _check_bin(PV_BIN)
 
 
-def compressed_pipe(path, size, rate_limit):
+def compressed_pipe(path, size, rate_limit, quiet):
     """
     Returns a generator that yields compressed chunks of
     the given file_path
@@ -107,8 +107,13 @@ def compressed_pipe(path, size, rate_limit):
     )
 
     if rate_limit > 0:
+        pv_cmd = [PV_BIN, '--rate-limit', '{}k'.format(rate_limit)]
+
+        if quiet:
+            pv_cmd.insert(1, '--quiet')
+
         pv = subprocess.Popen(
-            (PV_BIN, '--rate-limit', str(rate_limit) + 'k'),
+            pv_cmd,
             stdin=lzop.stdout,
             stdout=subprocess.PIPE
         )


### PR DESCRIPTION
- Add `--quiet` to set pv in quiet mode (i.e. don't show progress bar). Useful when cassandra_snapshotter is called from a script/cron.

For both "normal" and `--quiet` mode:
- Remove `lzop` and `pv` header when calling `lzop --version` and `pv --version`

