### PR TITLE
Add required Boto dependency: GCE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
   email:
     - tbarbugli@gmail.com
 install:
-  - pip install pep8
+  - pip install pep8 google_compute_engine
   - python setup.py install
 script:
   - "pep8 --ignore=E501,E225,W293,E731 cassandra_snapshotter"


### PR DESCRIPTION
See job failure: https://travis-ci.org/tbarbugli/cassandra_snapshotter/jobs/267917255
```
[...]
  File "/usr/lib/python2.7/dist-packages/google_compute_engine/boto/compute_auth.py", line 19, in <module>
    from google_compute_engine import logger
ImportError: No module named google_compute_engine
The command "python setup.py install" failed and exited with 1 during .
```
Kinda weird that GCE is mandatory for an AWS client.