### PR TITLE
Add support to configure path to snapshotter agent

### DIFF
--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -64,6 +64,7 @@ def run_backup(args):
         exclude_tables=args.exclude_tables,
         reduced_redundancy=args.reduced_redundancy,
         rate_limit=args.rate_limit,
+        snapshotter_agent_path=args.snapshotter_agent_path,
         quiet=args.quiet
     )
 
@@ -242,6 +243,11 @@ def main():
         '--rate-limit',
         default=0,
         help="Limit the upload speed to S3 (by using 'pv'). Value expressed in kilobytes (*1024)")
+
+    backup_parser.add_argument(
+        '--snapshotter-agent-path',
+        default='cassandra-snapshotter-agent',
+        help="Path to cassandra-snapshotter-agent")
 
     backup_parser.add_argument(
         '--quiet',


### PR DESCRIPTION
Add ability to configure the path to the snapshotter agent.

We've installed snapshotter in a virtualenv and not at the global system level.  As such, cassandra-snapshotter-agent is not globally accessible.  And as a result, when we run a backup, the remote command fails because it's unable to find the path to cassandra-snapshotter-agent.

This PR allows us to configure the path to the cassandra-snapshotter-agent when we execute the remote command.

Here is an example of how we can use this new parameter.
cassandra-snapshotter --s3-bucket-name=foo_backup_bucket ... --snapshotter-agent-path '... pyenv activate snapshotter-venv cassandra-snapshotter-agent'
